### PR TITLE
ugrep-indexer: init at 0.9.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@
   gitpolite = pkgs.callPackage ./pkgs/gi/gitpolite { };
   quiet = pkgs.callPackage ./pkgs/qu/quiet { };
   rmosxf = pkgs.callPackage ./pkgs/rm/rmosxf { };
+  ugrep-indexer = pkgs.callPackage ./pkgs/ug/ugrep-indexer {};
   # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
   # ...
 }

--- a/pkgs/ug/ugrep-indexer/default.nix
+++ b/pkgs/ug/ugrep-indexer/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, brotli
+, bzip2
+, lz4
+, xz
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ugrep-indexer";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "Genivia";
+    repo = "ugrep-indexer";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-hnnsowIbqNx4ZkTZX6PKaPzUHEWVAFjMmVNMlxWqSog=";
+  };
+
+  buildInputs = [
+    brotli
+    bzip2
+    lz4
+    zlib
+    zstd
+    xz
+  ];
+
+  meta = with lib; {
+    description = "Utility that recursively indexes files to speed up recursive grepping";
+    homepage = "https://github.com/Genivia/ugrep-indexer";
+    changelog = "https://github.com/Genivia/ugrep-indexer/releases/tag/v${finalAttrs.version}";
+    maintainers = with maintainers; [ mikaelfangel ];
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
### Changes
Add ugrep-indexer until it becomes adopted in nixpkgs (https://github.com/NixOS/nixpkgs/pull/270493) or becomes part of ugrep itself.

### Checklist
 - [x] Builds on Linux x86-64
 - [x] Test basic functionality by run ./result/bin